### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "mastodon-api",
     "mastodon-apis",
     "mastodon",
-    "rest-api"
-    "streaming",
+    "rest-api",
+    "streaming"
   ],
   "author": "Kirschn",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/Kirschn/mastodon.js/issues"
   },
-  "homepage": "https://github.com/Kirschn/mastodon.js#readme"
+  "homepage": "https://github.com/Kirschn/mastodon.js#readme",
+  "devDependencies": {
+    "eslint": "^4.4.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mastodon.js",
+  "version": "1.0.0",
+  "description": "Javascript Mastodon API Client Library for Browser Clients",
+  "main": "mastodon.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kirschn/mastodon.js.git"
+  },
+  "keywords": [
+    "mastodon-api",
+    "mastodon-apis",
+    "mastodon",
+    "rest-api"
+    "streaming",
+  ],
+  "author": "Kirschn",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Kirschn/mastodon.js/issues"
+  },
+  "homepage": "https://github.com/Kirschn/mastodon.js#readme"
+}


### PR DESCRIPTION
I added package.json for Node users. now we can install this package just by:
```
npm install https://github.com/Kirschn/mastodon.js.git
```
or
```
yarn add https://github.com/Kirschn/mastodon.js.git
```
that's cool.

And I wondered if I should add `jquery` for dependencies package, but even if installed jquery with npm not means able to use `$` in global (I have to do something like `$ = require("jquery")`),
So I decided to exclude it. However ESLint is in `devDependencies`.

